### PR TITLE
Rewrite pypdd with xarray.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. Copyright (c) 2013-2023, Julien Seguinot (juseg.dev)
+.. GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
+
 PyPDD
 =====
 
@@ -34,7 +37,7 @@ Installation::
 The PDDModel class
 ------------------
 
-**Requires:** NumPy_, SciPy_.
+**Requires:** NumPy_, SciPy_, Xarray_.
 
 A PDD model instance can be created by::
 
@@ -139,3 +142,4 @@ Applications of PyPDD:
 .. _Parallel Ice Sheet Model: http://www.pism-docs.org
 .. _PyPDD: https://github.com/jsegu/pypdd
 .. _SciPy: http://www.scipy.org
+.. _Xarray: https://xarray.dev

--- a/pypdd.py
+++ b/pypdd.py
@@ -358,7 +358,7 @@ class PDDModel():
         return (snow_melt, ice_melt)
 
     def nco(self, input_file, output_file,
-            output_size='small', output_variables=None, _diskless=False):
+            output_size='small', output_variables=None):
         """NetCDF operator.
 
         Read near-surface air temperature, precipitation rate, and standard
@@ -390,7 +390,7 @@ class PDDModel():
         # open netcdf files
         ids = nc4.Dataset(input_file, 'r')
         ods = nc4.Dataset(
-            output_file, 'w', format='NETCDF3_CLASSIC', diskless=_diskless)
+            output_file, 'w', format='NETCDF3_CLASSIC')
 
         # read input temperature data
         try:
@@ -468,8 +468,6 @@ class PDDModel():
 
         # close netcdf files
         ids.close()
-        if _diskless is True:
-            return ods
         ods.close()
 
 

--- a/pypdd.py
+++ b/pypdd.py
@@ -476,7 +476,7 @@ class PDDModel():
 # Command-line interface
 # ----------------------
 
-def make_fake_climate(filename):
+def make_fake_climate(filename='atm.nc'):
     """Create an artificial temperature and precipitation file.
 
     This function is used if pypdd.py is called as a script without an input
@@ -485,7 +485,7 @@ def make_fake_climate(filename):
     standard deviation of near-surface air temperature to be read by
     `PDDModel.nco`.
 
-    filename: str
+    filename: str, optional
         Name of output file.
     """
 
@@ -525,7 +525,7 @@ def make_fake_climate(filename):
     )
 
     # write dataset to file
-    ds.to_netcdf('atm.nc')
+    ds.to_netcdf(filename)
 
     # return dataset
     return ds

--- a/pypdd.py
+++ b/pypdd.py
@@ -474,7 +474,7 @@ class PDDModel():
 # Command-line interface
 # ----------------------
 
-def make_fake_climate(filename='atm.nc'):
+def make_fake_climate(filename=None):
     """Create an artificial temperature and precipitation file.
 
     This function is used if pypdd.py is called as a script without an input
@@ -527,7 +527,8 @@ def make_fake_climate(filename='atm.nc'):
     )
 
     # write dataset to file
-    ds.to_netcdf(filename)
+    if filename is not None:
+        ds.to_netcdf(filename)
 
     # return dataset
     return ds

--- a/pypdd.py
+++ b/pypdd.py
@@ -110,14 +110,6 @@ ATTRIBUTES = {
         'units':     'm'}}
 
 
-def _create_nc_variable(dataset, varname, dtype, dimensions):
-    """Create netCDF variable and apply default attributes"""
-    var = dataset.createVariable(varname, dtype, dimensions)
-    for (attr, value) in ATTRIBUTES[varname].items():
-        setattr(var, attr, value)
-    return var
-
-
 # PDD model class
 # ---------------
 

--- a/pypdd.py
+++ b/pypdd.py
@@ -192,17 +192,20 @@ class PDDModel():
         """
 
         # ensure numpy arrays
+        # FIXME use data arrays instead
         temp = np.asarray(temp)
         prec = np.asarray(prec)
         stdv = np.asarray(stdv)
 
         # expand arrays to the largest shape
+        # FIXME use xarray auto-broadcasting instead
         maxshape = max(temp.shape, prec.shape, stdv.shape)
         temp = self._expand(temp, maxshape)
         prec = self._expand(prec, maxshape)
         stdv = self._expand(stdv, maxshape)
 
         # interpolate time-series
+        # FIXME propagate data arrays, coordinates
         temp = self._interpolate(temp)
         prec = self._interpolate(prec)
         stdv = self._interpolate(stdv)

--- a/pypdd.py
+++ b/pypdd.py
@@ -229,25 +229,31 @@ class PDDModel():
                                 - self.refreeze_ice * ice_melt_rate
         inst_smb = accu_rate - runoff_rate
 
-        # output
-        return {'temp':           temp,
-                'prec':           prec,
-                'stdv':           stdv,
-                'inst_pdd':       inst_pdd,
-                'accu_rate':      accu_rate,
-                'snow_melt_rate': snow_melt_rate,
-                'ice_melt_rate':  ice_melt_rate,
-                'melt_rate':      melt_rate,
-                'runoff_rate':    runoff_rate,
-                'inst_smb':       inst_smb,
-                'snow_depth':     snow_depth,
-                'pdd':            self._integrate(inst_pdd),
-                'accu':           self._integrate(accu_rate),
-                'snow_melt':      self._integrate(snow_melt_rate),
-                'ice_melt':       self._integrate(ice_melt_rate),
-                'melt':           self._integrate(melt_rate),
-                'runoff':         self._integrate(runoff_rate),
-                'smb':            self._integrate(inst_smb)}
+        # make a dataset
+        # FIXME add coordinate variables
+        ds = xr.Dataset(
+            data_vars={
+                'temp': (['time', 'x', 'y'], temp),
+                'prec': (['time', 'x', 'y'], prec),
+                'stdv': (['time', 'x', 'y'], stdv),
+                'inst_pdd': (['time', 'x', 'y'], inst_pdd),
+                'accu_rate': (['time', 'x', 'y'], accu_rate),
+                'snow_melt_rate': (['time', 'x', 'y'], snow_melt_rate),
+                'ice_melt_rate': (['time', 'x', 'y'], ice_melt_rate),
+                'melt_rate': (['time', 'x', 'y'], melt_rate),
+                'runoff_rate': (['time', 'x', 'y'], runoff_rate),
+                'inst_smb': (['time', 'x', 'y'], inst_smb),
+                'snow_depth': (['time', 'x', 'y'], snow_depth),
+                'pdd': (['x', 'y'], self._integrate(inst_pdd)),
+                'accu': (['x', 'y'], self._integrate(accu_rate)),
+                'snow_melt': (['x', 'y'], self._integrate(snow_melt_rate)),
+                'ice_melt': (['x', 'y'], self._integrate(ice_melt_rate)),
+                'melt': (['x', 'y'], self._integrate(melt_rate)),
+                'runoff': (['x', 'y'], self._integrate(runoff_rate)),
+                'smb': (['x', 'y'], self._integrate(inst_smb))})
+
+        # return dataset
+        return ds
 
     def _expand(self, array, shape):
         """Expand an array to the given shape"""
@@ -640,7 +646,7 @@ def test():
         'pdd': 'c314959f12e41fd6c68ea619da71d000',
         'smb': '631c50ad64f268f82d530cc25e764c74'}
     for name, hash in hashes.items():
-        var = smb[name].astype('f4')
+        var = smb[name].data.astype('f4')
         assert hashlib.md5(var).hexdigest() == hash
 
 

--- a/pypdd.py
+++ b/pypdd.py
@@ -417,20 +417,16 @@ class PDDModel():
         # run PDD model
         smb = self(atm.temp, atm.prec, stdv=atm.get('stdv'))
 
-        # if output_variables was not defined, use output_size
-        if output_variables is None:
-            output_variables = ['pdd', 'smb']
-            if output_size in ('medium', 'big'):
-                output_variables += ['accu', 'snow_melt', 'ice_melt', 'melt',
-                                     'runoff']
-            if output_size == 'big':
-                output_variables += ['temp', 'prec', 'stdv', 'inst_pdd',
-                                     'accu_rate', 'snow_melt_rate',
-                                     'ice_melt_rate', 'melt_rate',
-                                     'runoff_rate', 'inst_smb', 'snow_depth']
+        # drop variables
+        if output_variables is not None:
+            smb = smb[output_variables]
+        elif output_size == 'small':
+            smb = smb[['pdd', 'smb']]
+        elif output_size == 'medium':
+            smb = smb[['pdd', 'smb', 'accu', 'snow_melt', 'ice_melt', 'melt',
+                       'runoff']]
 
         # write netcdf file
-        smb = smb[output_variables]
         smb.to_netcdf(output_file)
 
 

--- a/pypdd.py
+++ b/pypdd.py
@@ -628,20 +628,17 @@ def test():
     import hashlib
 
     # compute smb from fake climate
-    make_fake_climate('atm.nc')
+    ds = make_fake_climate()
     pdd = PDDModel()
-    ods = pdd.nco('atm.nc', 'smb.nc', _diskless=True)
+    smb = pdd(ds.temp, ds.prec, ds.stdv)
 
     # check md5 sums against v0.3.0
     hashes = {
         'pdd': 'c314959f12e41fd6c68ea619da71d000',
         'smb': '631c50ad64f268f82d530cc25e764c74'}
     for name, hash in hashes.items():
-        var = ods.variables[name][:]
+        var = smb[name].astype('f4')
         assert hashlib.md5(var).hexdigest() == hash
-
-    # close in-memory dataset
-    ods.close()
 
 
 if __name__ == '__main__':

--- a/pypdd.py
+++ b/pypdd.py
@@ -635,7 +635,7 @@ def main():
             output_variables=args.output_variables)
 
 
-def test():
+def test_pdd():
 
     import hashlib
 
@@ -643,6 +643,25 @@ def test():
     ds = make_fake_climate()
     pdd = PDDModel()
     smb = pdd(ds.temp, ds.prec, ds.stdv)
+
+    # check md5 sums against v0.3.0
+    hashes = {
+        'pdd': 'c314959f12e41fd6c68ea619da71d000',
+        'smb': '631c50ad64f268f82d530cc25e764c74'}
+    for name, hash in hashes.items():
+        var = smb[name].data.astype('f4')
+        assert hashlib.md5(var).hexdigest() == hash
+
+
+def test_nco():
+
+    import hashlib
+
+    # compute smb from fake climate
+    make_fake_climate('atm.nc')
+    pdd = PDDModel()
+    pdd.nco('atm.nc', 'smb.nc')
+    smb = xr.open_dataset('smb.nc')
 
     # check md5 sums against v0.3.0
     hashes = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "pypdd"
 version = "0.3.1"
 description = "A positive degree day model for glacier surface mass balance"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "COPYING"}
 keywords = ["glacier", "science"]
 authors = [{name = "Julien Seguinot"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Topic :: Scientific/Engineering",
 ]
-dependencies = ["numpy", "scipy"]
+dependencies = ["numpy", "scipy", "xarray"]
 
 [project.optional-dependencies]
 nco = ["netCDF4"]


### PR DESCRIPTION
The main call currently returns a dictionary of named numpy arrays, essentially a poorman's version of modern xarray datasets. Switching to xarray will simplify netcdf-related code, testing, improve usability, etc. 

- [x] Add xarray as required dependency.
- [x] Rewrite netCDF4 code using datasets.
- [x] Return a dataset instead of a dictionary.

Strictly speaking this will introduce backward-incompatible changes. However dictionary syntax remains largely valid on xarray `Dataset` objects so that I expect downstream code changes to be minimal.

```python
ds = pdd(temp, prec)
smb = ds['smb']
```